### PR TITLE
Bugfix/machine-class resource type

### DIFF
--- a/charts/internal/machine-class/templates/machine-class.yaml
+++ b/charts/internal/machine-class/templates/machine-class.yaml
@@ -16,28 +16,28 @@ apiVersion: machine.sapcloud.io/v1alpha1
 kind: MachineClass
 metadata:
   name: {{ $machineClass.name }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: "{{ $.Release.Namespace }}"
 providerSpec:
 {{- if $machineClass.storageClassName }}
-  storageClassName: {{ $machineClass.storageClassName }}
+  storageClassName: "{{ $machineClass.storageClassName }}"
 {{ end }}
 {{- if $machineClass.pvcSize }}
-  pvcSize: {{ $machineClass.pvcSize }}
+  pvcSize: "{{ $machineClass.pvcSize }}"
 {{ end }}
 {{- if $machineClass.sourceURL }}
-  sourceURL: {{ $machineClass.sourceURL }}
+  sourceURL: "{{ $machineClass.sourceURL }}"
 {{ end }}
 {{- if $machineClass.cpus }}
-  cpus: {{ $machineClass.cpus }}
+  cpus: "{{ $machineClass.cpus }}"
 {{ end }}
 {{- if $machineClass.memory }}
-  memory: {{ $machineClass.memory }}
+  memory: "{{ $machineClass.memory }}"
 {{ end }}
 {{- if $machineClass.namespace }}
-  namespace: {{ $machineClass.namespace }}
+  namespace: "{{ $machineClass.namespace }}"
 {{ end }}
 secretRef:
-  name: {{ $machineClass.name }}
-  namespace: {{ $.Release.Namespace }}
+  name: "{{ $machineClass.name }}"
+  namespace: "{{ $.Release.Namespace }}"
 provider: kubevirtdriver//127.0.0.1:8080
 {{- end }}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker
-->
/area quality
/kind bug
/priority normal
/platform kubevirt

**What this PR does / why we need it**:
Fixes an issue about wrong machine-class resources type
**Which issue(s) this PR fixes**:
Fixes #


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
