### PR TITLE
Use namespace from provider secret

### DIFF
--- a/charts/internal/machine-class/templates/machine-class.yaml
+++ b/charts/internal/machine-class/templates/machine-class.yaml
@@ -33,9 +33,6 @@ providerSpec:
 {{- if $machineClass.memory }}
   memory: "{{ $machineClass.memory }}"
 {{ end }}
-{{- if $machineClass.namespace }}
-  namespace: "{{ $machineClass.namespace }}"
-{{ end }}
 secretRef:
   name: "{{ $machineClass.name }}"
   namespace: "{{ $.Release.Namespace }}"

--- a/charts/internal/machine-class/values.yaml
+++ b/charts/internal/machine-class/values.yaml
@@ -11,4 +11,3 @@ machineClasses:
   sourceURL: source-image-url
   cpus: "1"
   memory: "4096M"
-  namespace: default

--- a/hack/api-reference/api.md
+++ b/hack/api-reference/api.md
@@ -280,17 +280,6 @@ string
 <p>MachineTypeName is the name of the machine type, used as a reference to MachineType object</p>
 </td>
 </tr>
-<tr>
-<td>
-<code>namespace</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Namespace is the name of the namespace where the machines should be deployed</p>
-</td>
-</tr>
 </tbody>
 </table>
 <h3 id="kubevirt.provider.extensions.gardener.cloud/v1alpha1.MachineImage">MachineImage

--- a/pkg/apis/kubevirt/types_cloudprofile.go
+++ b/pkg/apis/kubevirt/types_cloudprofile.go
@@ -51,6 +51,4 @@ type MachineImageVersion struct {
 type MachineDeploymentConfig struct {
 	// MachineTypeName is the name of the machine type, used as a reference to MachineType object
 	MachineTypeName string
-	// Namespace is the name of the namespace where the machines should be deployed
-	Namespace string
 }

--- a/pkg/apis/kubevirt/v1alpha1/types_cloudprofile.go
+++ b/pkg/apis/kubevirt/v1alpha1/types_cloudprofile.go
@@ -52,6 +52,4 @@ type MachineImageVersion struct {
 type MachineDeploymentConfig struct {
 	// MachineTypeName is the name of the machine type, used as a reference to MachineType object
 	MachineTypeName string `json:"machineTypeName"`
-	// Namespace is the name of the namespace where the machines should be deployed
-	Namespace string `json:"namespace"`
 }

--- a/pkg/apis/kubevirt/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kubevirt/v1alpha1/zz_generated.conversion.go
@@ -238,7 +238,6 @@ func Convert_kubevirt_InfrastructureStatus_To_v1alpha1_InfrastructureStatus(in *
 
 func autoConvert_v1alpha1_MachineDeploymentConfig_To_kubevirt_MachineDeploymentConfig(in *MachineDeploymentConfig, out *kubevirt.MachineDeploymentConfig, s conversion.Scope) error {
 	out.MachineTypeName = in.MachineTypeName
-	out.Namespace = in.Namespace
 	return nil
 }
 
@@ -249,7 +248,6 @@ func Convert_v1alpha1_MachineDeploymentConfig_To_kubevirt_MachineDeploymentConfi
 
 func autoConvert_kubevirt_MachineDeploymentConfig_To_v1alpha1_MachineDeploymentConfig(in *kubevirt.MachineDeploymentConfig, out *MachineDeploymentConfig, s conversion.Scope) error {
 	out.MachineTypeName = in.MachineTypeName
-	out.Namespace = in.Namespace
 	return nil
 }
 


### PR DESCRIPTION
**How to categorize this PR?**
/area control-plane
/kind enhancement
/priority normal
/platform kubevirt

**What this PR does / why we need it**:
Removes the namespace from the cloud profile and uses the namespace from the provider secret (default if empty). 

**Which issue(s) this PR fixes**:
Fixes #18 

**Special notes for your reviewer**:
Should be tested together with https://github.com/gardener/machine-controller-manager-provider-kubevirt/pull/9.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
