### PR TITLE
Pass user ssh keys to VMs

### DIFF
--- a/charts/internal/machine-class/templates/machine-class.yaml
+++ b/charts/internal/machine-class/templates/machine-class.yaml
@@ -33,6 +33,8 @@ providerSpec:
 {{- if $machineClass.memory }}
   memory: "{{ $machineClass.memory }}"
 {{ end }}
+  sshKeys:
+{{ toYaml $machineClass.sshKeys | indent 4 }}
 secretRef:
   name: "{{ $machineClass.name }}"
   namespace: "{{ $.Release.Namespace }}"

--- a/charts/internal/machine-class/values.yaml
+++ b/charts/internal/machine-class/values.yaml
@@ -1,13 +1,15 @@
 machineClasses:
 - name: class-1
-  secret:
-    cloudConfig: abc
-    kubeconfig: abc
-  tags:
-  - kubernetes.io/cluster/foo
-  - kubernetes.io/role/node
   storageClassName: standard
   pvcSize: "10Gi"
   sourceURL: source-image-url
   cpus: "1"
   memory: "4096M"
+  sshKeys:
+  - "ssh-rsa AAAAB3..."
+  tags:
+  - kubernetes.io/cluster/foo
+  - kubernetes.io/role/node
+  secret:
+    cloudConfig: abc
+    kubeconfig: abc

--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -74,6 +74,10 @@ func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
 		return err
 	}
 
+	if len(w.worker.Spec.SSHPublicKey) == 0 {
+		return fmt.Errorf("missing sshPublicKey in worker")
+	}
+
 	for _, pool := range w.worker.Spec.Pools {
 		// hardcoded for now as we don't support zones yet
 		zoneIdx := int32(0)
@@ -109,6 +113,7 @@ func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
 			"sourceURL":        imageSourceURL,
 			"cpus":             machineType.CPU,
 			"memory":           machineType.Memory,
+			"sshKeys":          []string{string(w.worker.Spec.SSHPublicKey)},
 			"tags": map[string]string{
 				"mcm.gardener.cloud/cluster": w.worker.Namespace,
 				"mcm.gardener.cloud/role":    "node",

--- a/pkg/controller/worker/machines_test.go
+++ b/pkg/controller/worker/machines_test.go
@@ -103,6 +103,7 @@ var _ = Describe("Machines", func() {
 			shootVersion := "1.2.3"
 			cloudProfileName := "test-profile"
 			ubuntuSourceURL := "https://cloud-images.ubuntu.com/xenial/current/xenial-server-cloudimg-amd64-disk1.img"
+			sshPublicKey := []byte("ssh-rsa AAAAB3...")
 
 			images := []apiv1alpha1.MachineImages{
 				{
@@ -164,7 +165,7 @@ var _ = Describe("Machines", func() {
 							Zones:    []string{},
 						},
 					},
-					SSHPublicKey: []byte{},
+					SSHPublicKey: sshPublicKey,
 				},
 			}
 
@@ -210,6 +211,7 @@ var _ = Describe("Machines", func() {
 					"8Gi",
 					"2",
 					"4096Mi",
+					sshPublicKey,
 				)
 
 				machineClass2 := generateMachineClass(
@@ -218,6 +220,7 @@ var _ = Describe("Machines", func() {
 					"8Gi",
 					"300m",
 					"8192Mi",
+					sshPublicKey,
 				)
 
 				chartApplier.
@@ -353,7 +356,7 @@ func generateKubeVirtSecret(c *mockclient.MockClient) {
 		})
 }
 
-func generateMachineClass(classTemplate map[string]interface{}, name, pvcSize, cpu, memory string) map[string]interface{} {
+func generateMachineClass(classTemplate map[string]interface{}, name, pvcSize, cpu, memory string, sshPublicKey []byte) map[string]interface{} {
 	out := make(map[string]interface{})
 
 	for k, v := range classTemplate {
@@ -364,6 +367,7 @@ func generateMachineClass(classTemplate map[string]interface{}, name, pvcSize, c
 	out["pvcSize"] = resource.MustParse(pvcSize)
 	out["cpus"] = resource.MustParse(cpu)
 	out["memory"] = resource.MustParse(memory)
+	out["sshKeys"] = []string{string(sshPublicKey)}
 
 	return out
 }


### PR DESCRIPTION
**How to categorize this PR?**
/area controlplane
/kind enhancement
/priority normal
/platform kubevirt

**What this PR does / why we need it**:
Implements reading the `sshPublicKey` from the worker resource and saving it in the machine class, so that it could be later used by the MCM extension, see https://github.com/gardener/machine-controller-manager-provider-kubevirt/pull/8.

**Which issue(s) this PR fixes**:
Fixes #10 

**Special notes for your reviewer**:
Based on #19, in draft state until that one is merged

**Release note**:
```improvement operator

```
