### PR TITLE
adding machineclass name to the labels

### DIFF
--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -180,8 +180,9 @@ func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
 			"sshKeys":          []string{string(w.worker.Spec.SSHPublicKey)},
 			"networks":         networks,
 			"tags": map[string]string{
-				"mcm.gardener.cloud/cluster": w.worker.Namespace,
-				"mcm.gardener.cloud/role":    "node",
+				"mcm.gardener.cloud/cluster":      w.worker.Namespace,
+				"mcm.gardener.cloud/role":         "node",
+				"mcm.gardener.cloud/machineclass": className,
 			},
 			"secret": map[string]interface{}{
 				"cloudConfig": string(pool.UserData),


### PR DESCRIPTION
**How to categorize this PR?**
/area storage
/kind enhancement
/priority blocker
/platform kubevirt

**What this PR does / why we need it**:
We need the machine class name in order to find the pre-allocated datavolume and reference it in the vm.

```improvement operator
None
```
