### PR TITLE
make pre-allocated data volumes configurable

### DIFF
--- a/hack/api-reference/api.md
+++ b/hack/api-reference/api.md
@@ -221,6 +221,19 @@ Parameters specified here will be merged to the generated DNS
 configuration based on DNSPolicy.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>DontUsePreAllocatedDataVolumes</code></br>
+<em>
+bool
+</em>
+</td>
+<td>
+<p>DontUsePreAllocatedDataVolumes specifies whether to create a DataVolume for any kubevirt machineclass, in order
+to reference it in the kubevirt VirtualMachine pvc to clone a new DataVolume out of the pre-allocated one. Default is
+false, which means for each created VirtualMachine a new DataVolume will be imported and allocated.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="kubevirt.provider.extensions.gardener.cloud/v1alpha1.WorkerStatus">WorkerStatus

--- a/pkg/apis/kubevirt/helper/scheme.go
+++ b/pkg/apis/kubevirt/helper/scheme.go
@@ -187,3 +187,17 @@ func DecodeCloudProfileConfig(config *runtime.RawExtension, fldPath *field.Path)
 
 	return cloudProfileConfig, nil
 }
+
+// DecodeWorkerConfig decodes the `WorkerConfig` from the given `RawExtension`.
+func DecodeWorkerConfig(decoder runtime.Decoder, worker *runtime.RawExtension) (*api.WorkerConfig, error) {
+	if worker == nil {
+		return nil, nil
+	}
+
+	workerConfig := &api.WorkerConfig{}
+	if err := util.Decode(decoder, worker.Raw, workerConfig); err != nil {
+		return nil, err
+	}
+
+	return workerConfig, nil
+}

--- a/pkg/apis/kubevirt/register.go
+++ b/pkg/apis/kubevirt/register.go
@@ -51,6 +51,7 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 		&ControlPlaneConfig{},
 		&WorkerConfig{},
 		&WorkerStatus{},
+		&WorkerConfig{},
 	)
 	return nil
 }

--- a/pkg/apis/kubevirt/types_worker.go
+++ b/pkg/apis/kubevirt/types_worker.go
@@ -36,6 +36,10 @@ type WorkerConfig struct {
 	// Parameters specified here will be merged to the generated DNS
 	// configuration based on DNSPolicy.
 	DNSConfig *corev1.PodDNSConfig
+	// DontUsePreAllocatedDataVolumes specifies whether to create a DataVolume for any kubevirt machineclass, in order
+	// to reference it in the kubevirt VirtualMachine pvc to clone a new DataVolume out of the pre-allocated one. Default is
+	// false, which means for each created VirtualMachine a new DataVolume will be imported and allocated.
+	DontUsePreAllocatedDataVolumes bool
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/kubevirt/v1alpha1/types_worker.go
+++ b/pkg/apis/kubevirt/v1alpha1/types_worker.go
@@ -37,6 +37,10 @@ type WorkerConfig struct {
 	// Parameters specified here will be merged to the generated DNS
 	// configuration based on DNSPolicy.
 	DNSConfig *corev1.PodDNSConfig `json:"dnsConfig,omitempty"`
+	// DontUsePreAllocatedDataVolumes specifies whether to create a DataVolume for any kubevirt machineclass, in order
+	// to reference it in the kubevirt VirtualMachine pvc to clone a new DataVolume out of the pre-allocated one. Default is
+	// false, which means for each created VirtualMachine a new DataVolume will be imported and allocated.
+	DontUsePreAllocatedDataVolumes bool
 }
 
 // +genclient

--- a/pkg/apis/kubevirt/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kubevirt/v1alpha1/zz_generated.conversion.go
@@ -444,6 +444,7 @@ func Convert_kubevirt_TenantNetwork_To_v1alpha1_TenantNetwork(in *kubevirt.Tenan
 func autoConvert_v1alpha1_WorkerConfig_To_kubevirt_WorkerConfig(in *WorkerConfig, out *kubevirt.WorkerConfig, s conversion.Scope) error {
 	out.DNSPolicy = v1.DNSPolicy(in.DNSPolicy)
 	out.DNSConfig = (*v1.PodDNSConfig)(unsafe.Pointer(in.DNSConfig))
+	out.DontUsePreAllocatedDataVolumes = in.DontUsePreAllocatedDataVolumes
 	return nil
 }
 
@@ -455,6 +456,7 @@ func Convert_v1alpha1_WorkerConfig_To_kubevirt_WorkerConfig(in *WorkerConfig, ou
 func autoConvert_kubevirt_WorkerConfig_To_v1alpha1_WorkerConfig(in *kubevirt.WorkerConfig, out *WorkerConfig, s conversion.Scope) error {
 	out.DNSPolicy = v1.DNSPolicy(in.DNSPolicy)
 	out.DNSConfig = (*v1.PodDNSConfig)(unsafe.Pointer(in.DNSConfig))
+	out.DontUsePreAllocatedDataVolumes = in.DontUsePreAllocatedDataVolumes
 	return nil
 }
 


### PR DESCRIPTION
**How to categorize this PR?**
/area high-availability
/area performance
/kind enhancement
/kind api-change
/priority normal
/platform kubevirt

**What this PR does / why we need it**:
Make the KubeVirt DataVolume pre-allocation configurable, in order to control the creation of the data volumes which going to be cloned.
**Which issue(s) this PR fixes**:
Fixes #56 

**Release note**:
```improvement operator
DataVolume pre-allocation configurability   
```
