### PR TITLE
Fix configuration for pre-allocated data volumes

### DIFF
--- a/hack/api-reference/api.md
+++ b/hack/api-reference/api.md
@@ -198,6 +198,7 @@ Kubernetes core/v1.DNSPolicy
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>Set DNS policy for the VM (the same as for the pod)
 Defaults to &ldquo;ClusterFirst&rdquo;.
 Valid values are &lsquo;ClusterFirstWithHostNet&rsquo;, &lsquo;ClusterFirst&rsquo;, &lsquo;Default&rsquo; or &lsquo;None&rsquo;.
@@ -216,6 +217,7 @@ Kubernetes core/v1.PodDNSConfig
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>Specifies the DNS parameters of a VM.
 Parameters specified here will be merged to the generated DNS
 configuration based on DNSPolicy.</p>
@@ -223,15 +225,16 @@ configuration based on DNSPolicy.</p>
 </tr>
 <tr>
 <td>
-<code>DontUsePreAllocatedDataVolumes</code></br>
+<code>dontUsePreAllocatedDataVolumes</code></br>
 <em>
 bool
 </em>
 </td>
 <td>
-<p>DontUsePreAllocatedDataVolumes specifies whether to create a DataVolume for any kubevirt machineclass, in order
-to reference it in the kubevirt VirtualMachine pvc to clone a new DataVolume out of the pre-allocated one. Default is
-false, which means for each created VirtualMachine a new DataVolume will be imported and allocated.</p>
+<em>(Optional)</em>
+<p>DontUsePreAllocatedDataVolumes specifies whether to create a DataVolume per kubevirt machineclass, in order
+to reference it in the kubevirt VirtualMachine PVC to clone a new DataVolume out of the pre-allocated one.
+Default is false.</p>
 </td>
 </tr>
 </tbody>

--- a/pkg/apis/kubevirt/helper/scheme.go
+++ b/pkg/apis/kubevirt/helper/scheme.go
@@ -189,14 +189,10 @@ func DecodeCloudProfileConfig(config *runtime.RawExtension, fldPath *field.Path)
 }
 
 // DecodeWorkerConfig decodes the `WorkerConfig` from the given `RawExtension`.
-func DecodeWorkerConfig(decoder runtime.Decoder, worker *runtime.RawExtension) (*api.WorkerConfig, error) {
-	if worker == nil {
-		return nil, nil
-	}
-
+func DecodeWorkerConfig(config *runtime.RawExtension, fldPath *field.Path) (*api.WorkerConfig, error) {
 	workerConfig := &api.WorkerConfig{}
-	if err := util.Decode(decoder, worker.Raw, workerConfig); err != nil {
-		return nil, err
+	if err := util.Decode(decoder, config.Raw, workerConfig); err != nil {
+		return nil, field.Invalid(fldPath, string(config.Raw), "cannot be decoded")
 	}
 
 	return workerConfig, nil

--- a/pkg/apis/kubevirt/types_worker.go
+++ b/pkg/apis/kubevirt/types_worker.go
@@ -36,9 +36,9 @@ type WorkerConfig struct {
 	// Parameters specified here will be merged to the generated DNS
 	// configuration based on DNSPolicy.
 	DNSConfig *corev1.PodDNSConfig
-	// DontUsePreAllocatedDataVolumes specifies whether to create a DataVolume for any kubevirt machineclass, in order
-	// to reference it in the kubevirt VirtualMachine pvc to clone a new DataVolume out of the pre-allocated one. Default is
-	// false, which means for each created VirtualMachine a new DataVolume will be imported and allocated.
+	// DontUsePreAllocatedDataVolumes specifies whether to create a DataVolume per kubevirt machineclass, in order
+	// to reference it in the kubevirt VirtualMachine PVC to clone a new DataVolume out of the pre-allocated one.
+	// Default is false.
 	DontUsePreAllocatedDataVolumes bool
 }
 

--- a/pkg/apis/kubevirt/v1alpha1/types_worker.go
+++ b/pkg/apis/kubevirt/v1alpha1/types_worker.go
@@ -32,15 +32,18 @@ type WorkerConfig struct {
 	// DNS parameters given in DNSConfig will be merged with the policy selected with DNSPolicy.
 	// To have DNS options set along with hostNetwork, you have to specify DNS policy
 	// explicitly to 'ClusterFirstWithHostNet'.
+	// +optional
 	DNSPolicy corev1.DNSPolicy `json:"dnsPolicy,omitempty"`
 	// Specifies the DNS parameters of a VM.
 	// Parameters specified here will be merged to the generated DNS
 	// configuration based on DNSPolicy.
+	// +optional
 	DNSConfig *corev1.PodDNSConfig `json:"dnsConfig,omitempty"`
-	// DontUsePreAllocatedDataVolumes specifies whether to create a DataVolume for any kubevirt machineclass, in order
-	// to reference it in the kubevirt VirtualMachine pvc to clone a new DataVolume out of the pre-allocated one. Default is
-	// false, which means for each created VirtualMachine a new DataVolume will be imported and allocated.
-	DontUsePreAllocatedDataVolumes bool
+	// DontUsePreAllocatedDataVolumes specifies whether to create a DataVolume per kubevirt machineclass, in order
+	// to reference it in the kubevirt VirtualMachine PVC to clone a new DataVolume out of the pre-allocated one.
+	// Default is false.
+	// +optional
+	DontUsePreAllocatedDataVolumes bool `json:"dontUsePreAllocatedDataVolumes,omitempty"`
 }
 
 // +genclient

--- a/pkg/controller/worker/machines_test.go
+++ b/pkg/controller/worker/machines_test.go
@@ -180,6 +180,7 @@ var _ = Describe("Machines", func() {
 									DNSConfig: &corev1.PodDNSConfig{
 										Nameservers: []string{dnsNameserver},
 									},
+									DontUsePreAllocatedDataVolumes: true,
 								}),
 							},
 						},
@@ -269,6 +270,7 @@ var _ = Describe("Machines", func() {
 					&corev1.PodDNSConfig{
 						Nameservers: []string{dnsNameserver},
 					},
+					true,
 				)
 
 				machineClass2 := generateMachineClass(
@@ -285,6 +287,7 @@ var _ = Describe("Machines", func() {
 					},
 					"",
 					nil,
+					false,
 				)
 
 				chartApplier.
@@ -482,7 +485,7 @@ func generateKubeVirtDataVolumes(providerClient *mockclient.MockClient) {
 }
 
 func generateMachineClass(classTemplate map[string]interface{}, name, pvcSize, cpu, memory string, zones []string,
-	tags map[string]string, dnsPolicy corev1.DNSPolicy, dnsConfig *corev1.PodDNSConfig) map[string]interface{} {
+	tags map[string]string, dnsPolicy corev1.DNSPolicy, dnsConfig *corev1.PodDNSConfig, dontUsePreAllocatedDataVolumes bool) map[string]interface{} {
 	out := make(map[string]interface{})
 
 	for k, v := range classTemplate {
@@ -497,6 +500,7 @@ func generateMachineClass(classTemplate map[string]interface{}, name, pvcSize, c
 	out["tags"] = tags
 	out["dnsPolicy"] = dnsPolicy
 	out["dnsConfig"] = dnsConfig
+	out["dontUsePreAllocatedDataVolumes"] = dontUsePreAllocatedDataVolumes
 
 	return out
 }

--- a/pkg/kubevirt/data_volume.go
+++ b/pkg/kubevirt/data_volume.go
@@ -127,11 +127,6 @@ func (d *defaultDataVolumeManager) ListDataVolumes(ctx context.Context, kubeconf
 		return nil, errors.Wrapf(err, "could not list DataVolumes in namespace %s", namespace)
 	}
 
-	if len(dvList.Items) == 0 {
-		d.logger.V(2).Info("namespace %s has no data volumes", namespace)
-		return nil, nil
-	}
-
 	return &dvList, nil
 }
 


### PR DESCRIPTION
**How to categorize this PR?**

/area storage
/kind bug
/priority normal
/platform kubevirt

**What this PR does / why we need it**:
Fixes a few issues introduced previously with #60:
* `DeployMachineClasses` iterates over all pools and for each pool creates data volumes for all machine classes, not just for the machine class corresponding to that particular pool.
* Nil pointer panic in `actuator_delete.go` when `ListDataVolumes` returns an empty list.
* Missing `+optional` and JSON tag for `DontUsePreAllocatedDataVolumes` in `v1alpha1`
* Inconsistent `DecodeWorkerConfig` function in `helper` and workerConfig validation logic in `validator`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```improvement operator
NONE
```
