### PR TITLE
Rename dontUsePreAllocatedDataVolumes to disablePreAllocatedDataVolumes

### DIFF
--- a/docs/usage-as-end-user.md
+++ b/docs/usage-as-end-user.md
@@ -123,14 +123,14 @@ dnsPolicy: ClusterFirst
 dnsConfig:
   nameservers:
   - 8.8.8.8
-# Don't use pre-allocated data volumes. Defaults to 'false'.
-dontUsePreallocatedDataVolumes: true
+# Disable using pre-allocated data volumes. Defaults to 'false'.
+disablePreAllocatedDataVolumes: true
 ```
 
 Currently, these KubeVirt-specific options may include:
 
 * The DNS policy and DNS configuration for the KubeVirt VMs used as shoot cluster nodes. For more information, see [DNS for Services and Pods](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/).
-* Whether to use *pre-allocated data volumes* with KubeVirt VMs. With pre-allocated data volumes (the default), a data volume is created in advance for each machine class / worker pool, the OS image is imported into this volume only once, and actual KubeVirt VM data volumes are cloned from this data volume. Typically, this significantly speeds up the data volume creation process. You can disable this feature by setting the `dontUsePreallocatedDataVolumes` option to `false`.
+* Whether to use *pre-allocated data volumes* with KubeVirt VMs. With pre-allocated data volumes (the default), a data volume is created in advance for each machine class / worker pool, the OS image is imported into this volume only once, and actual KubeVirt VM data volumes are cloned from this data volume. Typically, this significantly speeds up the data volume creation process. You can disable this feature by setting the `disablePreAllocatedDataVolumes` option to `true`.
 
 ## Region and Zone Support
 
@@ -223,7 +223,7 @@ spec:
 #       dnsConfig:
 #         nameservers:
 #         - 8.8.8.8
-#       dontUsePreallocatedDataVolumes: true
+#       disablePreAllocatedDataVolumes: true
       minimum: 1
       maximum: 2
       zones:

--- a/hack/api-reference/api.md
+++ b/hack/api-reference/api.md
@@ -225,16 +225,14 @@ configuration based on DNSPolicy.</p>
 </tr>
 <tr>
 <td>
-<code>dontUsePreAllocatedDataVolumes</code></br>
+<code>disablePreAllocatedDataVolumes</code></br>
 <em>
 bool
 </em>
 </td>
 <td>
 <em>(Optional)</em>
-<p>DontUsePreAllocatedDataVolumes specifies whether to create a DataVolume per kubevirt machineclass, in order
-to reference it in the kubevirt VirtualMachine PVC to clone a new DataVolume out of the pre-allocated one.
-Default is false.</p>
+<p>DisablePreAllocatedDataVolumes disables using pre-allocated DataVolumes for VMs. Default is false.</p>
 </td>
 </tr>
 </tbody>

--- a/pkg/apis/kubevirt/types_worker.go
+++ b/pkg/apis/kubevirt/types_worker.go
@@ -36,10 +36,8 @@ type WorkerConfig struct {
 	// Parameters specified here will be merged to the generated DNS
 	// configuration based on DNSPolicy.
 	DNSConfig *corev1.PodDNSConfig
-	// DontUsePreAllocatedDataVolumes specifies whether to create a DataVolume per kubevirt machineclass, in order
-	// to reference it in the kubevirt VirtualMachine PVC to clone a new DataVolume out of the pre-allocated one.
-	// Default is false.
-	DontUsePreAllocatedDataVolumes bool
+	// DisablePreAllocatedDataVolumes disables using pre-allocated DataVolumes for VMs. Default is false.
+	DisablePreAllocatedDataVolumes bool
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/kubevirt/v1alpha1/types_worker.go
+++ b/pkg/apis/kubevirt/v1alpha1/types_worker.go
@@ -39,11 +39,9 @@ type WorkerConfig struct {
 	// configuration based on DNSPolicy.
 	// +optional
 	DNSConfig *corev1.PodDNSConfig `json:"dnsConfig,omitempty"`
-	// DontUsePreAllocatedDataVolumes specifies whether to create a DataVolume per kubevirt machineclass, in order
-	// to reference it in the kubevirt VirtualMachine PVC to clone a new DataVolume out of the pre-allocated one.
-	// Default is false.
+	// DisablePreAllocatedDataVolumes disables using pre-allocated DataVolumes for VMs. Default is false.
 	// +optional
-	DontUsePreAllocatedDataVolumes bool `json:"dontUsePreAllocatedDataVolumes,omitempty"`
+	DisablePreAllocatedDataVolumes bool `json:"disablePreAllocatedDataVolumes,omitempty"`
 }
 
 // +genclient

--- a/pkg/apis/kubevirt/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kubevirt/v1alpha1/zz_generated.conversion.go
@@ -444,7 +444,7 @@ func Convert_kubevirt_TenantNetwork_To_v1alpha1_TenantNetwork(in *kubevirt.Tenan
 func autoConvert_v1alpha1_WorkerConfig_To_kubevirt_WorkerConfig(in *WorkerConfig, out *kubevirt.WorkerConfig, s conversion.Scope) error {
 	out.DNSPolicy = v1.DNSPolicy(in.DNSPolicy)
 	out.DNSConfig = (*v1.PodDNSConfig)(unsafe.Pointer(in.DNSConfig))
-	out.DontUsePreAllocatedDataVolumes = in.DontUsePreAllocatedDataVolumes
+	out.DisablePreAllocatedDataVolumes = in.DisablePreAllocatedDataVolumes
 	return nil
 }
 
@@ -456,7 +456,7 @@ func Convert_v1alpha1_WorkerConfig_To_kubevirt_WorkerConfig(in *WorkerConfig, ou
 func autoConvert_kubevirt_WorkerConfig_To_v1alpha1_WorkerConfig(in *kubevirt.WorkerConfig, out *WorkerConfig, s conversion.Scope) error {
 	out.DNSPolicy = v1.DNSPolicy(in.DNSPolicy)
 	out.DNSConfig = (*v1.PodDNSConfig)(unsafe.Pointer(in.DNSConfig))
-	out.DontUsePreAllocatedDataVolumes = in.DontUsePreAllocatedDataVolumes
+	out.DisablePreAllocatedDataVolumes = in.DisablePreAllocatedDataVolumes
 	return nil
 }
 

--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -162,7 +162,7 @@ func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
 			},
 			"dnsPolicy":                      workerConfig.DNSPolicy,
 			"dnsConfig":                      workerConfig.DNSConfig,
-			"dontUsePreAllocatedDataVolumes": workerConfig.DontUsePreAllocatedDataVolumes,
+			"disablePreAllocatedDataVolumes": workerConfig.DisablePreAllocatedDataVolumes,
 		})
 
 		machineDeployments = append(machineDeployments, worker.MachineDeployment{
@@ -207,7 +207,7 @@ func (w *workerDelegate) allocateDataVolumes(ctx context.Context) error {
 	}
 
 	for _, machineClass := range w.machineClasses {
-		if !machineClass["dontUsePreAllocatedDataVolumes"].(bool) {
+		if !machineClass["disablePreAllocatedDataVolumes"].(bool) {
 			var (
 				storageClassName = pointer.StringPtr(machineClass["storageClassName"].(string))
 				pvcSize          = v1.ResourceList{v1.ResourceStorage: machineClass["pvcSize"].(resource.Quantity)}

--- a/pkg/controller/worker/machines_test.go
+++ b/pkg/controller/worker/machines_test.go
@@ -180,7 +180,7 @@ var _ = Describe("Machines", func() {
 									DNSConfig: &corev1.PodDNSConfig{
 										Nameservers: []string{dnsNameserver},
 									},
-									DontUsePreAllocatedDataVolumes: true,
+									DisablePreAllocatedDataVolumes: true,
 								}),
 							},
 						},
@@ -485,7 +485,7 @@ func generateKubeVirtDataVolumes(providerClient *mockclient.MockClient) {
 }
 
 func generateMachineClass(classTemplate map[string]interface{}, name, pvcSize, cpu, memory string, zones []string,
-	tags map[string]string, dnsPolicy corev1.DNSPolicy, dnsConfig *corev1.PodDNSConfig, dontUsePreAllocatedDataVolumes bool) map[string]interface{} {
+	tags map[string]string, dnsPolicy corev1.DNSPolicy, dnsConfig *corev1.PodDNSConfig, disablePreAllocatedDataVolumes bool) map[string]interface{} {
 	out := make(map[string]interface{})
 
 	for k, v := range classTemplate {
@@ -500,7 +500,7 @@ func generateMachineClass(classTemplate map[string]interface{}, name, pvcSize, c
 	out["tags"] = tags
 	out["dnsPolicy"] = dnsPolicy
 	out["dnsConfig"] = dnsConfig
-	out["dontUsePreAllocatedDataVolumes"] = dontUsePreAllocatedDataVolumes
+	out["disablePreAllocatedDataVolumes"] = disablePreAllocatedDataVolumes
 
 	return out
 }


### PR DESCRIPTION

**How to categorize this PR?**

/area storage
/kind technical-debt
/priority normal
/platform kubevirt

**What this PR does / why we need it**:
Renames `dontUsePreAllocatedDataVolumes` to `useDynamicallyAllocatedDataVolumes` to avoid using "don't" and double negation.

**Which issue(s) this PR fixes**:
Fixes #65

**Special notes for your reviewer**:

**Release note**:
```improvement operator
NONE
```
