### PR TITLE
Add proper validation for InfrastructureConfig

### DIFF
--- a/pkg/apis/kubevirt/validation/controlplane.go
+++ b/pkg/apis/kubevirt/validation/controlplane.go
@@ -21,7 +21,7 @@ import (
 )
 
 // ValidateControlPlaneConfig validates a ControlPlaneConfig object.
-func ValidateControlPlaneConfig(controlPlaneConfig *apiskubevirt.ControlPlaneConfig, fldPath *field.Path) field.ErrorList {
+func ValidateControlPlaneConfig(config *apiskubevirt.ControlPlaneConfig, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	return allErrs
 }

--- a/pkg/apis/kubevirt/validation/worker.go
+++ b/pkg/apis/kubevirt/validation/worker.go
@@ -21,7 +21,7 @@ import (
 )
 
 // ValidateWorkerConfig validates a WorkerConfig object.
-func ValidateWorkerConfig(controlPlaneConfig *apiskubevirt.WorkerConfig, fldPath *field.Path) field.ErrorList {
+func ValidateWorkerConfig(config *apiskubevirt.WorkerConfig, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	return allErrs
 }


### PR DESCRIPTION
**How to categorize this PR?**

/area usability
/kind enhancement
/priority normal
/platform kubevirt

**What this PR does / why we need it**:
Adds proper validation for `InfrastructureConfig` resources.

**Which issue(s) this PR fixes**:
Fixes #39 

**Special notes for your reviewer**:
As discussed, the other validations mentioned in the issue are either not needed or could not be added at this point. They should be added later if needed.

**Release note**:
```improvement operator
NONE
```
