### PR TITLE
 Ensure that machines are recreated when networks change

### DIFF
--- a/docs/usage-as-end-user.md
+++ b/docs/usage-as-end-user.md
@@ -85,7 +85,9 @@ A non-empty infrastructure configuration can contain:
 
 Both shared and tenant networks are maintained in the provider cluster via [Multus CNI](https://github.com/intel/multus-cni/blob/master/README.md) [NetworkAttachmentDefinition](https://intel.github.io/multus-cni/doc/quickstart.html) resources. For shared networks, these resources must be created in advance, while for tenant networks they are managed by the shoot reconciliation process.
 
-In order to use any additional CNI plugins in a tenant network configuration, such as `bridge` or `firewall` in the above example, the plugin binaries must be present in the `/opt/cni/bin` directory of the provider cluster nodes. They can be installed manually by downloading a [containernetworking/plugins](https://github.com/containernetworking/plugins) release (not recommended except for testing a new configuration). Alternatively, they can be installed via a specially prepared daemon set that ensures the existence of the plugin binaries on each provider cluster node. 
+In order to use any additional CNI plugins in a tenant network configuration, such as `bridge` or `firewall` in the above example, the plugin binaries must be present in the `/opt/cni/bin` directory of the provider cluster nodes. They can be installed manually by downloading a [containernetworking/plugins](https://github.com/containernetworking/plugins) release (not recommended except for testing a new configuration). Alternatively, they can be installed via a specially prepared daemon set that ensures the existence of the plugin binaries on each provider cluster node.
+
+**Note:** Although it is possible to update the network configuration in `InfrastructureConfig`, any such changes will result in recreating all KubeVirt VMs, so that the new network configuration is properly taken into account. This will be done automatically by the MCM using rolling update.
 
 ## `ControlPlaneConfig`
 

--- a/hack/api-reference/api.md
+++ b/hack/api-reference/api.md
@@ -356,6 +356,7 @@ map[string]bool
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>Networks is the status of the infrastructure networks.</p>
 </td>
 </tr>
@@ -577,6 +578,18 @@ bool
 <td>
 <em>(Optional)</em>
 <p>Default is whether the network is the default or not.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>sha</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>SHA is an SHA256 checksum of the network configuration.</p>
 </td>
 </tr>
 </tbody>

--- a/pkg/apis/kubevirt/types_infrastructure.go
+++ b/pkg/apis/kubevirt/types_infrastructure.go
@@ -68,4 +68,6 @@ type NetworkStatus struct {
 	Name string
 	// Default is whether the network is the default or not.
 	Default bool
+	// SHA is an SHA256 checksum of the network configuration.
+	SHA string
 }

--- a/pkg/apis/kubevirt/v1alpha1/types_infrastructure.go
+++ b/pkg/apis/kubevirt/v1alpha1/types_infrastructure.go
@@ -64,7 +64,8 @@ type TenantNetwork struct {
 type InfrastructureStatus struct {
 	metav1.TypeMeta `json:",inline"`
 	// Networks is the status of the infrastructure networks.
-	Networks []NetworkStatus `json:"networks"`
+	// +optional
+	Networks []NetworkStatus `json:"networks,omitempty"`
 }
 
 // NetworkStatus contains information about the status of an infrastructure network.
@@ -74,4 +75,7 @@ type NetworkStatus struct {
 	// Default is whether the network is the default or not.
 	// +optional
 	Default bool `json:"default,omitempty"`
+	// SHA is an SHA256 checksum of the network configuration.
+	// +optional
+	SHA string `json:"sha,omitempty"`
 }

--- a/pkg/apis/kubevirt/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/kubevirt/v1alpha1/zz_generated.conversion.go
@@ -377,6 +377,7 @@ func Convert_kubevirt_NetworkAttachmentDefinitionReference_To_v1alpha1_NetworkAt
 func autoConvert_v1alpha1_NetworkStatus_To_kubevirt_NetworkStatus(in *NetworkStatus, out *kubevirt.NetworkStatus, s conversion.Scope) error {
 	out.Name = in.Name
 	out.Default = in.Default
+	out.SHA = in.SHA
 	return nil
 }
 
@@ -388,6 +389,7 @@ func Convert_v1alpha1_NetworkStatus_To_kubevirt_NetworkStatus(in *NetworkStatus,
 func autoConvert_kubevirt_NetworkStatus_To_v1alpha1_NetworkStatus(in *kubevirt.NetworkStatus, out *NetworkStatus, s conversion.Scope) error {
 	out.Name = in.Name
 	out.Default = in.Default
+	out.SHA = in.SHA
 	return nil
 }
 

--- a/pkg/controller/infrastructure/actuator_reconcile.go
+++ b/pkg/controller/infrastructure/actuator_reconcile.go
@@ -24,6 +24,7 @@ import (
 
 	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/gardener/gardener/pkg/utils"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	networkv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	"github.com/pkg/errors"
@@ -97,6 +98,7 @@ func (a *actuator) Reconcile(ctx context.Context, infra *extensionsv1alpha1.Infr
 		networks = append(networks, kubevirtv1alpha1.NetworkStatus{
 			Name:    kutil.ObjectName(nad),
 			Default: tenantNetwork.Default,
+			SHA:     utils.ComputeSHA256Hex([]byte(tenantNetwork.Config)),
 		})
 	}
 

--- a/pkg/controller/worker/machines_test.go
+++ b/pkg/controller/worker/machines_test.go
@@ -119,6 +119,7 @@ var _ = Describe("Machines", func() {
 			sshPublicKey := []byte("ssh-rsa AAAAB3...")
 			machineConfiguration := &machinev1alpha1.MachineConfiguration{}
 			networkName := "default/net-conf"
+			networkSHA := "abc"
 			dnsNameserver := "8.8.8.8"
 
 			images := []kubevirtv1alpha1.MachineImages{
@@ -153,6 +154,7 @@ var _ = Describe("Machines", func() {
 								{
 									Name:    networkName,
 									Default: true,
+									SHA:     networkSHA,
 								},
 							},
 						}),
@@ -222,8 +224,8 @@ var _ = Describe("Machines", func() {
 
 				cluster = createCluster(cloudProfileName, shootVersion, images)
 
-				workerPoolHash1, _ = worker.WorkerPoolHash(w.Spec.Pools[0], cluster)
-				workerPoolHash2, _ = worker.WorkerPoolHash(w.Spec.Pools[1], cluster)
+				workerPoolHash1, _ = worker.WorkerPoolHash(w.Spec.Pools[0], cluster, networkName, "true", networkSHA)
+				workerPoolHash2, _ = worker.WorkerPoolHash(w.Spec.Pools[1], cluster, networkName, "true", networkSHA)
 				workerDelegate, _ = NewWorkerDelegate(common.NewClientContext(c, scheme, decoder), chartApplier, "", w, cluster, dataVolumeManager)
 			})
 
@@ -242,10 +244,11 @@ var _ = Describe("Machines", func() {
 					"sshKeys": []string{
 						string(sshPublicKey),
 					},
-					"networks": []map[string]interface{}{
+					"networks": []kubevirtv1alpha1.NetworkStatus{
 						{
-							"name":    networkName,
-							"default": true,
+							Name:    networkName,
+							Default: true,
+							SHA:     networkSHA,
 						},
 					},
 					"region": "local",


### PR DESCRIPTION
**How to categorize this PR?**

/area robustness
/kind enhancement
/priority normal
/platform kubevirt

**What this PR does / why we need it**:
Ensures that machines are recreated when networks change, so that the new network setup is properly taken into account for all worker nodes. Any change in networks now results in new machine classes being created by the worker controller.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Based on #75, can be merged after that one is merged.

**Release note**:
```improvement operator
NONE
```
