### PR TITLE
fix VM resources type in a machine class chart

### DIFF
--- a/charts/internal/machine-class/templates/machine-class.yaml
+++ b/charts/internal/machine-class/templates/machine-class.yaml
@@ -19,7 +19,8 @@ metadata:
   namespace: "{{ $.Release.Namespace }}"
 providerSpec:
 {{- if $machineClass.resources }}
-  resources: "{{ $machineClass.resources }}"
+  resources:
+{{ toYaml $machineClass.resources | indent 4 }}
 {{ end }}
 {{- if $machineClass.storageClassName }}
   storageClassName: "{{ $machineClass.storageClassName }}"


### PR DESCRIPTION
Signed-off-by: Marcin Franczyk <marcin0franczyk@gmail.com>

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind bug
/priority normal
/platform kubevirt

**What this PR does / why we need it**:
Fixes incorrect resource type in machine class

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
improvement_user
```
