### PR TITLE
dns policy and config validation

### DIFF
--- a/pkg/apis/kubevirt/validation/worker.go
+++ b/pkg/apis/kubevirt/validation/worker.go
@@ -15,14 +15,42 @@
 package validation
 
 import (
+	"fmt"
+
 	apiskubevirt "github.com/gardener/gardener-extension-provider-kubevirt/pkg/apis/kubevirt"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
 // ValidateWorkerConfig validates a WorkerConfig object.
 func ValidateWorkerConfig(config *apiskubevirt.WorkerConfig, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
+
+	if config.DNSPolicy != "" {
+		dnsPolicyPath := fldPath.Child("dnsPolicy")
+		dnsConfigPath := fldPath.Child("dnsConfig")
+
+		switch config.DNSPolicy {
+		case corev1.DNSDefault, corev1.DNSClusterFirstWithHostNet, corev1.DNSClusterFirst, corev1.DNSNone:
+			break
+		default:
+			allErrs = append(allErrs, field.Invalid(dnsPolicyPath, config.DNSPolicy, "invalid dns policy"))
+		}
+
+		if config.DNSPolicy == corev1.DNSNone {
+			if config.DNSConfig != nil {
+				if len(config.DNSConfig.Nameservers) == 0 {
+					allErrs = append(allErrs, field.Required(dnsConfigPath.Child("nameservers"),
+						fmt.Sprintf("cannot be empty when dns policy is %s", corev1.DNSNone)))
+				}
+			} else {
+				allErrs = append(allErrs, field.Required(dnsConfigPath,
+					fmt.Sprintf("cannot be empty when dns policy is %s", corev1.DNSNone)))
+			}
+		}
+	}
+
 	return allErrs
 }
 


### PR DESCRIPTION
Signed-off-by: Marcin Franczyk <marcin0franczyk@gmail.com>

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind enhancement
/priority normal
/platform kubevirt

**What this PR does / why we need it**:
Adds validation for DNS

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
improvement_user
```
