### PR TITLE
Add support for volume types and additional volumes

### DIFF
--- a/charts/internal/machine-class/Chart.yaml
+++ b/charts/internal/machine-class/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for KubeVirtMachineClasses controlled by the machine-controller-manager in the shoot cluster
-name: machineclass
+name: machine-class
 version: 0.1.0

--- a/charts/internal/machine-class/templates/machine-class.yaml
+++ b/charts/internal/machine-class/templates/machine-class.yaml
@@ -21,16 +21,15 @@ providerSpec:
 {{- if $machineClass.resources }}
   resources:
 {{ toYaml $machineClass.resources | indent 4 }}
-{{ end }}
-{{- if $machineClass.storageClassName }}
-  storageClassName: "{{ $machineClass.storageClassName }}"
-{{ end }}
-{{- if $machineClass.pvcSize }}
-  pvcSize: "{{ $machineClass.pvcSize }}"
-{{ end }}
-{{- if $machineClass.sourceURL }}
-  sourceURL: "{{ $machineClass.sourceURL }}"
-{{ end }}
+{{- end }}
+{{- if $machineClass.rootVolume }}
+  rootVolume:
+{{ toYaml $machineClass.rootVolume | indent 4 }}
+{{- end }}
+{{- if $machineClass.additionalVolumes }}
+  additionalVolumes:
+{{ toYaml $machineClass.additionalVolumes | indent 4 }}
+{{- end }}
   sshKeys:
 {{ toYaml $machineClass.sshKeys | indent 4 }}
 {{- if $machineClass.networks }}

--- a/charts/internal/machine-class/values.yaml
+++ b/charts/internal/machine-class/values.yaml
@@ -8,9 +8,28 @@ machineClasses:
       cpu: "300m"
       memory: "4Gi"
     overcommitGuestOverhead: true
-  storageClassName: standard
-  pvcSize: "10Gi"
-  sourceURL: source-image-url
+  rootVolume:
+    pvc:
+      storageClassName: standard
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 10Gi
+    source:
+      http:
+        url: source-image-url
+  additionalVolumes:
+  - dataVolume:
+      pvc:
+        storageClassName: standard
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 10Gi
+      source:
+        blank: {}
   sshKeys:
   - "ssh-rsa AAAAB3..."
   networks:

--- a/docs/usage-as-operator.md
+++ b/docs/usage-as-operator.md
@@ -57,11 +57,9 @@ spec:
     cpu: "1"
     gpu: "0"
     memory: 4Gi
-    storage:
-      class: default
-      type: DataVolume
-      size: 20Gi
-    usable: true
+  volumeTypes:
+  - name: default
+    class: default
   regions:
   - name: europe-west1
     zones:

--- a/pkg/apis/kubevirt/validation/shoot.go
+++ b/pkg/apis/kubevirt/validation/shoot.go
@@ -38,8 +38,18 @@ func ValidateWorkers(workers []core.Worker, fldPath *field.Path) field.ErrorList
 	allErrs := field.ErrorList{}
 
 	for i, worker := range workers {
-
 		workerFldPath := fldPath.Index(i)
+
+		if worker.Volume == nil {
+			allErrs = append(allErrs, field.Required(workerFldPath.Child("volume"), "must not be nil"))
+		} else {
+			allErrs = append(allErrs, validateVolume(worker.Volume, workerFldPath.Child("volume"))...)
+		}
+
+		for j, dataVolume := range worker.DataVolumes {
+			allErrs = append(allErrs, validateDataVolume(&dataVolume, workerFldPath.Child("dataVolumes").Index(j))...)
+		}
+
 		if len(worker.Zones) == 0 {
 			allErrs = append(allErrs, field.Required(workerFldPath.Child("zones"), "at least one zone must be configured"))
 			continue
@@ -59,6 +69,22 @@ func ValidateWorkers(workers []core.Worker, fldPath *field.Path) field.ErrorList
 		}
 	}
 
+	return allErrs
+}
+
+func validateVolume(vol *core.Volume, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+	if vol.Type == nil {
+		allErrs = append(allErrs, field.Required(fldPath.Child("type"), "must not be empty"))
+	}
+	return allErrs
+}
+
+func validateDataVolume(vol *core.DataVolume, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+	if vol.Type == nil {
+		allErrs = append(allErrs, field.Required(fldPath.Child("type"), "must not be empty"))
+	}
 	return allErrs
 }
 

--- a/pkg/apis/kubevirt/validation/shoot_test.go
+++ b/pkg/apis/kubevirt/validation/shoot_test.go
@@ -67,6 +67,12 @@ var _ = Describe("Shoot validation", func() {
 						Type:       pointer.StringPtr("Volume"),
 						VolumeSize: "30G",
 					},
+					DataVolumes: []core.DataVolume{
+						{
+							Type:       pointer.StringPtr("DataVolume"),
+							VolumeSize: "20G",
+						},
+					},
 					Minimum: 1,
 					Maximum: 2,
 					Zones:   []string{"1", "2"},
@@ -90,6 +96,45 @@ var _ = Describe("Shoot validation", func() {
 				errorList := ValidateWorkers(workers, nilPath)
 
 				Expect(errorList).To(BeEmpty())
+			})
+
+			It("should forbid because worker does not specify a volume", func() {
+				workers[0].Volume = nil
+
+				errorList := ValidateWorkers(workers, nilPath)
+
+				Expect(errorList).To(ConsistOf(
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":  Equal(field.ErrorTypeRequired),
+						"Field": Equal("[0].volume"),
+					})),
+				))
+			})
+
+			It("should forbid because worker volume does not have a type", func() {
+				workers[0].Volume.Type = nil
+
+				errorList := ValidateWorkers(workers, nilPath)
+
+				Expect(errorList).To(ConsistOf(
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":  Equal(field.ErrorTypeRequired),
+						"Field": Equal("[0].volume.type"),
+					})),
+				))
+			})
+
+			It("should forbid because worker data volume does not have a type", func() {
+				workers[0].DataVolumes[0].Type = nil
+
+				errorList := ValidateWorkers(workers, nilPath)
+
+				Expect(errorList).To(ConsistOf(
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":  Equal(field.ErrorTypeRequired),
+						"Field": Equal("[0].dataVolumes[0].type"),
+					})),
+				))
 			})
 
 			It("should forbid because worker does not specify a zone", func() {

--- a/pkg/controller/worker/add.go
+++ b/pkg/controller/worker/add.go
@@ -54,13 +54,15 @@ func AddToManagerWithOptions(mgr manager.Manager, opts AddOptions) error {
 		return err
 	}
 
-	dataVolumeManager, err := kubevirt.NewDefaultDataVolumeManager(kubevirt.ClientFactoryFunc(kubevirt.GetClient))
+	clientFactory := kubevirt.ClientFactoryFunc(kubevirt.GetClient)
+	dataVolumeManager, err := kubevirt.NewDefaultDataVolumeManager(clientFactory)
 	if err != nil {
 		return errors.Wrap(err, "could not create kubevirt data volume manager")
 	}
 
 	delegateFactory := &delegateFactory{
 		logger:            workerLogger,
+		clientFactory:     clientFactory,
 		dataVolumeManager: dataVolumeManager,
 	}
 


### PR DESCRIPTION
**How to categorize this PR?**

/area storage
/kind enhancement
/priority normal
/platform kubevirt

**What this PR does / why we need it**:
Adds support for volume types in the cloud profile and specifying root volume and additional volumes in the worker pools.

**Which issue(s) this PR fixes**:
Fixes #68 

**Special notes for your reviewer**:
Should be merged together with https://github.com/gardener/machine-controller-manager-provider-kubevirt/pull/25.

**Release note**:
```improvement operator
NONE
```
