### PR TITLE
Ensure consistent error wrapping and error messages

### DIFF
--- a/pkg/admission/decode.go
+++ b/pkg/admission/decode.go
@@ -18,6 +18,7 @@ import (
 	apiskubevirt "github.com/gardener/gardener-extension-provider-kubevirt/pkg/apis/kubevirt"
 
 	"github.com/gardener/gardener/extensions/pkg/util"
+	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -25,7 +26,7 @@ import (
 func DecodeWorkerConfig(decoder runtime.Decoder, worker *runtime.RawExtension) (*apiskubevirt.WorkerConfig, error) {
 	workerConfig := &apiskubevirt.WorkerConfig{}
 	if err := util.Decode(decoder, worker.Raw, workerConfig); err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "could not decode WorkerConfig")
 	}
 
 	return workerConfig, nil
@@ -35,7 +36,7 @@ func DecodeWorkerConfig(decoder runtime.Decoder, worker *runtime.RawExtension) (
 func DecodeControlPlaneConfig(decoder runtime.Decoder, cp *runtime.RawExtension) (*apiskubevirt.ControlPlaneConfig, error) {
 	controlPlaneConfig := &apiskubevirt.ControlPlaneConfig{}
 	if err := util.Decode(decoder, cp.Raw, controlPlaneConfig); err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "could not decode ControlPlaneConfig")
 	}
 
 	return controlPlaneConfig, nil
@@ -45,7 +46,7 @@ func DecodeControlPlaneConfig(decoder runtime.Decoder, cp *runtime.RawExtension)
 func DecodeInfrastructureConfig(decoder runtime.Decoder, infra *runtime.RawExtension) (*apiskubevirt.InfrastructureConfig, error) {
 	infraConfig := &apiskubevirt.InfrastructureConfig{}
 	if err := util.Decode(decoder, infra.Raw, infraConfig); err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "could not decode InfrastructureConfig")
 	}
 
 	return infraConfig, nil
@@ -55,7 +56,7 @@ func DecodeInfrastructureConfig(decoder runtime.Decoder, infra *runtime.RawExten
 func DecodeCloudProfileConfig(decoder runtime.Decoder, config *runtime.RawExtension) (*apiskubevirt.CloudProfileConfig, error) {
 	cloudProfileConfig := &apiskubevirt.CloudProfileConfig{}
 	if err := util.Decode(decoder, config.Raw, cloudProfileConfig); err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "could not decode CloudProfileConfig")
 	}
 
 	return cloudProfileConfig, nil

--- a/pkg/admission/validator/cloudprofile.go
+++ b/pkg/admission/validator/cloudprofile.go
@@ -58,7 +58,7 @@ func (cp *cloudProfile) Validate(ctx context.Context, new, old runtime.Object) e
 
 	cpConfig, err := admission.DecodeCloudProfileConfig(cp.decoder, cloudProfile.Spec.ProviderConfig)
 	if err != nil {
-		return errors.Wrapf(err, "could not decode providerConfig in cloud profile %q", cloudProfile.Name)
+		return errors.Wrapf(err, "could not decode providerConfig of cloud profile %q", cloudProfile.Name)
 	}
 
 	return validation.ValidateCloudProfileConfig(&cloudProfile.Spec, cpConfig).ToAggregate()

--- a/pkg/admission/validator/shoot.go
+++ b/pkg/admission/validator/shoot.go
@@ -178,7 +178,7 @@ func (s *shoot) newValidationContext(ctx context.Context, shoot *core.Shoot) (*v
 		var err error
 		infrastructureConfig, err = admission.DecodeInfrastructureConfig(s.decoder, shoot.Spec.Provider.InfrastructureConfig)
 		if err != nil {
-			return nil, errors.Wrap(err, "could not decode infrastructureConfig")
+			return nil, errors.Wrapf(err, "could not decode infrastructureConfig of shoot %q", shoot.Name)
 		}
 	}
 
@@ -187,7 +187,7 @@ func (s *shoot) newValidationContext(ctx context.Context, shoot *core.Shoot) (*v
 		var err error
 		controlPlaneConfig, err = admission.DecodeControlPlaneConfig(s.decoder, shoot.Spec.Provider.ControlPlaneConfig)
 		if err != nil {
-			return nil, errors.Wrap(err, "could not decode controlPlaneConfig")
+			return nil, errors.Wrapf(err, "could not decode controlPlaneConfig of shoot %q", shoot.Name)
 		}
 	}
 
@@ -198,7 +198,7 @@ func (s *shoot) newValidationContext(ctx context.Context, shoot *core.Shoot) (*v
 			var err error
 			workerConfig, err = admission.DecodeWorkerConfig(s.decoder, worker.ProviderConfig)
 			if err != nil {
-				return nil, errors.Wrapf(err, "could not decode providerConfig in worker %q", worker.Name)
+				return nil, errors.Wrapf(err, "could not decode providerConfig of worker %q", worker.Name)
 			}
 		}
 		workerConfigs = append(workerConfigs, workerConfig)
@@ -210,11 +210,11 @@ func (s *shoot) newValidationContext(ctx context.Context, shoot *core.Shoot) (*v
 	}
 
 	if cloudProfile.Spec.ProviderConfig == nil {
-		return nil, errors.Errorf("providerConfig is not specified in cloud profile %q", cloudProfile.Name)
+		return nil, errors.Errorf("missing providerConfig in cloud profile %q", cloudProfile.Name)
 	}
 	cloudProfileConfig, err := admission.DecodeCloudProfileConfig(s.decoder, cloudProfile.Spec.ProviderConfig)
 	if err != nil {
-		return nil, errors.Wrapf(err, "could not decode providerConfig in cloud profile %q", cloudProfile.Name)
+		return nil, errors.Wrapf(err, "could not decode providerConfig of cloud profile %q", cloudProfile.Name)
 	}
 
 	return &validationContext{

--- a/pkg/apis/config/loader/loader.go
+++ b/pkg/apis/config/loader/loader.go
@@ -20,6 +20,7 @@ import (
 	"github.com/gardener/gardener-extension-provider-kubevirt/pkg/apis/config"
 	"github.com/gardener/gardener-extension-provider-kubevirt/pkg/apis/config/install"
 
+	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer/json"
@@ -48,7 +49,7 @@ func init() {
 func LoadFromFile(filename string) (*config.ControllerConfiguration, error) {
 	bytes, err := ioutil.ReadFile(filename)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrapf(err, "could not read file %q", filename)
 	}
 
 	return Load(bytes)
@@ -65,7 +66,7 @@ func Load(data []byte) (*config.ControllerConfiguration, error) {
 
 	decoded, _, err := codec.Decode(data, &schema.GroupVersionKind{Version: "v1alpha1", Kind: "Config"}, cfg)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "could not decode controller configuration")
 	}
 
 	return decoded.(*config.ControllerConfiguration), nil

--- a/pkg/apis/kubevirt/helper/helper.go
+++ b/pkg/apis/kubevirt/helper/helper.go
@@ -15,9 +15,9 @@
 package helper
 
 import (
-	"fmt"
-
 	apiskubevirt "github.com/gardener/gardener-extension-provider-kubevirt/pkg/apis/kubevirt"
+
+	"github.com/pkg/errors"
 )
 
 // FindMachineImage takes a list of machine images and tries to find the first entry
@@ -29,7 +29,7 @@ func FindMachineImage(configImages []apiskubevirt.MachineImage, imageName, image
 			return &machineImage, nil
 		}
 	}
-	return nil, fmt.Errorf("no machine image with name %q, version %q found", imageName, imageVersion)
+	return nil, errors.Errorf("machine image with name %q and version %q not found", imageName, imageVersion)
 }
 
 // FindImage takes a list of machine images, and the desired image name and version. It tries
@@ -50,5 +50,5 @@ func FindImage(profileImages []apiskubevirt.MachineImages, imageName, imageVersi
 		}
 	}
 
-	return "", fmt.Errorf("could not find an image for name %q in version %q", imageName, imageVersion)
+	return "", errors.Errorf("machine image with name %q and version %q not found", imageName, imageVersion)
 }

--- a/pkg/apis/kubevirt/validation/secret.go
+++ b/pkg/apis/kubevirt/validation/secret.go
@@ -30,7 +30,7 @@ func ValidateCloudProviderSecret(secret *corev1.Secret) error {
 	}
 
 	if _, err := clientcmd.RESTConfigFromKubeConfig(kubeconfig); err != nil {
-		return errors.Wrapf(err, "invalid kubeconfig")
+		return errors.Wrapf(err, "could not create REST config from kubeconfig")
 	}
 
 	return nil

--- a/pkg/cmd/config.go
+++ b/pkg/cmd/config.go
@@ -15,12 +15,11 @@
 package cmd
 
 import (
-	"fmt"
-
 	"github.com/gardener/gardener-extension-provider-kubevirt/pkg/apis/config"
 	configloader "github.com/gardener/gardener-extension-provider-kubevirt/pkg/apis/config/loader"
 
 	healthcheckconfig "github.com/gardener/gardener/extensions/pkg/controller/healthcheck/config"
+	"github.com/pkg/errors"
 	"github.com/spf13/pflag"
 )
 
@@ -40,7 +39,7 @@ type Config struct {
 
 func (c *ConfigOptions) buildConfig() (*config.ControllerConfiguration, error) {
 	if len(c.ConfigFilePath) == 0 {
-		return nil, fmt.Errorf("config file path not set")
+		return nil, errors.New("config file path not set")
 	}
 	return configloader.LoadFromFile(c.ConfigFilePath)
 }

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -147,7 +147,7 @@ func (vp *valuesProvider) GetConfigChartValues(
 	// Get kubeconfig
 	kubeconfig, err := kubevirt.GetKubeConfig(ctx, vp.Client(), cp.Spec.SecretRef)
 	if err != nil {
-		return nil, errors.Wrapf(err, "could not get kubeconfig from secret '%s/%s'", cp.Spec.SecretRef.Namespace, cp.Spec.SecretRef.Name)
+		return nil, errors.Wrap(err, "could not get kubeconfig from controlplane secret reference")
 	}
 
 	// Get config chart values

--- a/pkg/controller/healthcheck/add.go
+++ b/pkg/controller/healthcheck/add.go
@@ -28,6 +28,7 @@ import (
 	extensionspredicate "github.com/gardener/gardener/extensions/pkg/predicate"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -59,10 +60,10 @@ func RegisterHealthChecks(mgr manager.Manager, opts healthcheck.DefaultAddArgs) 
 				HealthCheck:   general.CheckManagedResource(genericcontrolplaneactuator.ControlPlaneShootChartResourceName),
 			},
 		}); err != nil {
-		return err
+		return errors.Wrap(err, "could not register healthchecks for controlplane resources")
 	}
 
-	return healthcheck.DefaultRegistration(
+	if err := healthcheck.DefaultRegistration(
 		kubevirt.Type,
 		extensionsv1alpha1.SchemeGroupVersion.WithKind(extensionsv1alpha1.WorkerResource),
 		func() runtime.Object { return &extensionsv1alpha1.WorkerList{} },
@@ -83,7 +84,11 @@ func RegisterHealthChecks(mgr manager.Manager, opts healthcheck.DefaultAddArgs) 
 				ConditionType: string(gardencorev1beta1.ShootEveryNodeReady),
 				HealthCheck:   worker.NewNodesChecker(),
 			},
-		})
+		}); err != nil {
+		return errors.Wrap(err, "could not register healthchecks for worker resources")
+	}
+
+	return nil
 }
 
 // AddToManager adds a controller with the default Options.

--- a/pkg/controller/infrastructure/actuator_delete.go
+++ b/pkg/controller/infrastructure/actuator_delete.go
@@ -46,7 +46,7 @@ func (a *actuator) Delete(ctx context.Context, infra *extensionsv1alpha1.Infrast
 	// Get a client and a namespace for the provider cluster from the kubeconfig
 	providerClient, namespace, err := kubevirt.GetClient(kubeconfig)
 	if err != nil {
-		return errors.Wrap(err, "could not get client from kubeconfig")
+		return errors.Wrap(err, "could not create client from kubeconfig")
 	}
 
 	// Delete tenant networks
@@ -63,7 +63,7 @@ func (a *actuator) Delete(ctx context.Context, infra *extensionsv1alpha1.Infrast
 			},
 		}
 		if err := client.IgnoreNotFound(providerClient.Delete(ctx, nad)); err != nil {
-			return errors.Wrapf(err, "could not delete NetworkAttachmentDefinition '%s'", kutil.ObjectName(nad))
+			return errors.Wrapf(err, "could not delete NetworkAttachmentDefinition %q", kutil.ObjectName(nad))
 		}
 	}
 

--- a/pkg/controller/infrastructure/actuator_reconcile.go
+++ b/pkg/controller/infrastructure/actuator_reconcile.go
@@ -60,7 +60,7 @@ func (a *actuator) Reconcile(ctx context.Context, infra *extensionsv1alpha1.Infr
 	// Get a client and a namespace for the provider cluster from the kubeconfig
 	providerClient, namespace, err := kubevirt.GetClient(kubeconfig)
 	if err != nil {
-		return errors.Wrap(err, "could not get client from kubeconfig")
+		return errors.Wrap(err, "could not create client from kubeconfig")
 	}
 
 	var networks []kubevirtv1alpha1.NetworkStatus
@@ -91,7 +91,7 @@ func (a *actuator) Reconcile(ctx context.Context, infra *extensionsv1alpha1.Infr
 			})
 			return err
 		}); err != nil {
-			return errors.Wrapf(err, "could not create or update NetworkAttachmentDefinition '%s'", kutil.ObjectName(nad))
+			return errors.Wrapf(err, "could not create or update NetworkAttachmentDefinition %q", kutil.ObjectName(nad))
 		}
 
 		// Add the tenant network to the list of networks
@@ -106,7 +106,7 @@ func (a *actuator) Reconcile(ctx context.Context, infra *extensionsv1alpha1.Infr
 	// Check if the NetworkAttachmentDefinition CRD exists
 	var crdErr error
 	if crdErr = providerClient.Get(ctx, kutil.Key("", nadCRDName), &apiextensionsv1beta1.CustomResourceDefinition{}); crdErr != nil && !apierrors.IsNotFound(crdErr) {
-		return errors.Wrapf(err, "could not get CRD '%v'", nadCRDName)
+		return errors.Wrapf(err, "could not get CRD %q", nadCRDName)
 	}
 	if crdErr == nil {
 		// List all tenant networks in namespace
@@ -120,7 +120,7 @@ func (a *actuator) Reconcile(ctx context.Context, infra *extensionsv1alpha1.Infr
 				// Delete the NetworkAttachmentDefinition of the tenant network in the provider cluster
 				a.logger.Info("Deleting NetworkAttachmentDefinition", "name", nad.Name, "namespace", nad.Namespace)
 				if err := client.IgnoreNotFound(providerClient.Delete(ctx, &nad)); err != nil {
-					return errors.Wrapf(err, "could not delete NetworkAttachmentDefinition '%s'", kutil.ObjectName(&nad))
+					return errors.Wrapf(err, "could not delete NetworkAttachmentDefinition %q", kutil.ObjectName(&nad))
 				}
 			}
 		}

--- a/pkg/controller/worker/actuator.go
+++ b/pkg/controller/worker/actuator.go
@@ -28,6 +28,7 @@ import (
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	gardener "github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/go-logr/logr"
+	"github.com/pkg/errors"
 	"k8s.io/client-go/kubernetes"
 	cdicorev1alpha1 "kubevirt.io/containerized-data-importer/pkg/apis/core/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -79,17 +80,17 @@ type delegateFactory struct {
 func (d *delegateFactory) WorkerDelegate(ctx context.Context, worker *extensionsv1alpha1.Worker, cluster *extensionscontroller.Cluster) (genericactuator.WorkerDelegate, error) {
 	clientset, err := kubernetes.NewForConfig(d.RESTConfig())
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "could not create clientset from REST config")
 	}
 
 	serverVersion, err := clientset.Discovery().ServerVersion()
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "could not get server version")
 	}
 
 	seedChartApplier, err := gardener.NewChartApplierForConfig(d.RESTConfig())
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "could not create chart applier from REST config")
 	}
 
 	return NewWorkerDelegate(
@@ -140,7 +141,7 @@ func NewWorkerDelegate(
 	if cluster != nil {
 		cloudProfileConfig, err = helper.GetCloudProfileConfig(cluster.CloudProfile)
 		if err != nil {
-			return nil, err
+			return nil, errors.Wrap(err, "could not get CloudProfileConfig from cloud profile")
 		}
 	}
 

--- a/pkg/controller/worker/actuator_reconcile.go
+++ b/pkg/controller/worker/actuator_reconcile.go
@@ -28,17 +28,17 @@ import (
 
 func (a *actuator) Reconcile(ctx context.Context, worker *extensionsv1alpha1.Worker, cluster *extensionscontroller.Cluster) error {
 	if err := a.Actuator.Reconcile(ctx, worker, cluster); err != nil {
-		return errors.Wrap(err, "could not reconcile worker resouces")
+		return errors.Wrap(err, "could not reconcile worker")
 	}
 
 	kubeconfig, err := kubevirt.GetKubeConfig(ctx, a.client, worker.Spec.SecretRef)
 	if err != nil {
-		return errors.Wrap(err, "could not get kubevirt kubeconfig from worker secret ref")
+		return errors.Wrap(err, "could not get kubeconfig from worker secret reference")
 	}
 
 	machineClasses := &machinev1alpha1.MachineClassList{}
 	if err := a.client.List(ctx, machineClasses, client.InNamespace(worker.Namespace)); err != nil {
-		return errors.Wrapf(err, "could not list machine classes in namespace %s", worker.Namespace)
+		return errors.Wrapf(err, "could not list machine classes in namespace %q", worker.Namespace)
 	}
 
 	return a.deleteDataVolumes(ctx, kubeconfig, worker, machineClasses)

--- a/pkg/controller/worker/add.go
+++ b/pkg/controller/worker/add.go
@@ -17,11 +17,11 @@ package worker
 import (
 	"github.com/gardener/gardener-extension-provider-kubevirt/pkg/imagevector"
 	"github.com/gardener/gardener-extension-provider-kubevirt/pkg/kubevirt"
-	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
-	"github.com/gardener/gardener/extensions/pkg/util"
 
+	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
 	"github.com/gardener/gardener/extensions/pkg/controller/worker"
 	"github.com/gardener/gardener/extensions/pkg/controller/worker/genericactuator"
+	"github.com/gardener/gardener/extensions/pkg/util"
 	machinescheme "github.com/gardener/machine-controller-manager/pkg/client/clientset/versioned/scheme"
 	"github.com/pkg/errors"
 	apiextensionsscheme "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/scheme"
@@ -48,10 +48,10 @@ type AddOptions struct {
 func AddToManagerWithOptions(mgr manager.Manager, opts AddOptions) error {
 	scheme := mgr.GetScheme()
 	if err := apiextensionsscheme.AddToScheme(scheme); err != nil {
-		return err
+		return errors.Wrap(err, "could not update manager scheme")
 	}
 	if err := machinescheme.AddToScheme(scheme); err != nil {
-		return err
+		return errors.Wrap(err, "could not update manager scheme")
 	}
 
 	clientFactory := kubevirt.ClientFactoryFunc(kubevirt.GetClient)

--- a/pkg/controller/worker/machine_controller_manager.go
+++ b/pkg/controller/worker/machine_controller_manager.go
@@ -25,6 +25,7 @@ import (
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/utils/chart"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -58,7 +59,7 @@ var (
 func (w *workerDelegate) GetMachineControllerManagerChartValues(ctx context.Context) (map[string]interface{}, error) {
 	namespace := &corev1.Namespace{}
 	if err := w.Client().Get(ctx, kutil.Key(w.worker.Namespace), namespace); err != nil {
-		return nil, err
+		return nil, errors.Wrapf(err, "could not get namespace %q", namespace)
 	}
 
 	return map[string]interface{}{

--- a/pkg/controller/worker/machines_test.go
+++ b/pkg/controller/worker/machines_test.go
@@ -20,6 +20,7 @@ package worker_test
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -527,7 +528,7 @@ var _ = Describe("Machines", func() {
 			It("should fail when the kubevirt secret cannot be read", func() {
 				c.EXPECT().
 					Get(context.TODO(), gomock.Any(), gomock.AssignableToTypeOf(&corev1.Secret{})).
-					Return(fmt.Errorf("error"))
+					Return(errors.New("error"))
 
 				result, err := workerDelegate.GenerateMachineDeployments(context.TODO())
 				Expect(err).To(HaveOccurred())

--- a/pkg/kubevirt/data_volume.go
+++ b/pkg/kubevirt/data_volume.go
@@ -74,7 +74,7 @@ func NewDefaultDataVolumeManager(client ClientFactory) (DataVolumeManager, error
 func (d *defaultDataVolumeManager) CreateOrUpdateDataVolume(ctx context.Context, kubeconfig []byte, name string, labels map[string]string, dataVolumeSpec cdicorev1alpha1.DataVolumeSpec) error {
 	c, namespace, err := d.client.GetClient(kubeconfig)
 	if err != nil {
-		return errors.Wrap(err, "could not create kubevirt client")
+		return errors.Wrap(err, "could not create client from kubeconfig")
 	}
 
 	dataVolume := &cdicorev1alpha1.DataVolume{}
@@ -88,7 +88,7 @@ func (d *defaultDataVolumeManager) CreateOrUpdateDataVolume(ctx context.Context,
 	})
 
 	if err != nil {
-		return errors.Wrapf(err, "could not create or update DataVolume '%s'", kutil.ObjectName(dataVolume))
+		return errors.Wrapf(err, "could not create or update DataVolume %q", kutil.ObjectName(dataVolume))
 	}
 
 	return nil
@@ -99,7 +99,7 @@ func (d *defaultDataVolumeManager) CreateOrUpdateDataVolume(ctx context.Context,
 func (d *defaultDataVolumeManager) GetDataVolume(ctx context.Context, kubeconfig []byte, name string) (*cdicorev1alpha1.DataVolume, error) {
 	c, namespace, err := d.client.GetClient(kubeconfig)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not create kubevirt client")
+		return nil, errors.Wrap(err, "could not create client from kubeconfig")
 	}
 
 	dataVolume := &cdicorev1alpha1.DataVolume{}
@@ -108,7 +108,7 @@ func (d *defaultDataVolumeManager) GetDataVolume(ctx context.Context, kubeconfig
 			return nil, nil
 		}
 
-		return nil, errors.Wrapf(err, "could not get DataVolume: %s", name)
+		return nil, errors.Wrapf(err, "could not get DataVolume %q", name)
 	}
 
 	return dataVolume, nil
@@ -119,12 +119,12 @@ func (d *defaultDataVolumeManager) ListDataVolumes(ctx context.Context, kubeconf
 	c, namespace, err := d.client.GetClient(kubeconfig)
 
 	if err != nil {
-		return nil, errors.Wrap(err, "could not create kubevirt client")
+		return nil, errors.Wrap(err, "could not create client from kubeconfig")
 	}
 
 	dvList := cdicorev1alpha1.DataVolumeList{}
 	if err := c.List(ctx, &dvList, listOpts...); err != nil {
-		return nil, errors.Wrapf(err, "could not list DataVolumes in namespace %s", namespace)
+		return nil, errors.Wrapf(err, "could not list DataVolumes in namespace %q", namespace)
 	}
 
 	return &dvList, nil
@@ -134,7 +134,7 @@ func (d *defaultDataVolumeManager) ListDataVolumes(ctx context.Context, kubeconf
 func (d *defaultDataVolumeManager) DeleteDataVolume(ctx context.Context, kubeconfig []byte, name string) error {
 	c, namespace, err := d.client.GetClient(kubeconfig)
 	if err != nil {
-		return errors.Wrap(err, "could not create kubevirt client")
+		return errors.Wrap(err, "could not create client from kubeconfig")
 	}
 
 	dv := &cdicorev1alpha1.DataVolume{

--- a/pkg/webhook/controlplane/ensurer.go
+++ b/pkg/webhook/controlplane/ensurer.go
@@ -58,17 +58,17 @@ func (e *ensurer) EnsureKubeAPIServerDeployment(ctx context.Context, ectx generi
 
 	cluster, err := ectx.GetCluster(ctx)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "could not get cluster")
 	}
 
 	if cluster.Shoot != nil && cluster.Seed != nil && cluster.Shoot.Spec.Networking.Nodes != nil {
 		shootNodesIP, _, err := net.ParseCIDR(*cluster.Shoot.Spec.Networking.Nodes)
 		if err != nil {
-			return errors.Wrapf(err, "could not parse shoot nodes CIDR %s", *cluster.Shoot.Spec.Networking.Nodes)
+			return errors.Wrapf(err, "could not parse shoot nodes CIDR %q", *cluster.Shoot.Spec.Networking.Nodes)
 		}
 		_, seedPodsIPNet, err := net.ParseCIDR(cluster.Seed.Spec.Networks.Pods)
 		if err != nil {
-			return errors.Wrapf(err, "could not parse seed pods CIDR %s", cluster.Seed.Spec.Networks.Pods)
+			return errors.Wrapf(err, "could not parse seed pods CIDR %q", cluster.Seed.Spec.Networks.Pods)
 		}
 
 		// If the seed pods CIDR contains the shoot nodes CIDR (the seed cluster hosts the shoot cluster),

--- a/pkg/webhook/controlplaneexposure/ensurer.go
+++ b/pkg/webhook/controlplaneexposure/ensurer.go
@@ -62,7 +62,7 @@ func (e *ensurer) EnsureKubeAPIServerDeployment(ctx context.Context, ectx generi
 
 	cluster, err := controller.GetCluster(ctx, e.client, new.Namespace)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "could not get cluster")
 	}
 
 	if controller.IsHibernated(cluster) {


### PR DESCRIPTION
**How to categorize this PR?**

/area quality
/kind technical-debt
/priority normal
/platform kubevirt

**What this PR does / why we need it**:
Ensures consistent error wrapping and error messages:
* All errors from other packages are wrapped with `errors.Wrap` or `errors.Wrapf`.
* All new errors are reported with `errors.New` and `errors.Errorf`.
* Using `fmt.Errorf` is avoided.
* Error messages are reworded to ensure that similar / identical errors are reported with similar / identical messages.
* String values are always quoted with `%q` in error messages.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```improvement operator
NONE
```
