### PR TITLE
Refactor infra controller, add kubevirt NetworkManager

### DIFF
--- a/pkg/controller/infrastructure/actuator.go
+++ b/pkg/controller/infrastructure/actuator.go
@@ -15,22 +15,25 @@
 package infrastructure
 
 import (
+	"github.com/gardener/gardener-extension-provider-kubevirt/pkg/kubevirt"
+
 	"github.com/gardener/gardener/extensions/pkg/controller/common"
 	"github.com/gardener/gardener/extensions/pkg/controller/infrastructure"
 	"github.com/go-logr/logr"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 type actuator struct {
 	common.ChartRendererContext
 
-	logger logr.Logger
+	networkManager kubevirt.NetworkManager
+	logger         logr.Logger
 }
 
 // NewActuator creates a new Actuator that updates the status of the handled Infrastructure resources.
-func NewActuator() infrastructure.Actuator {
+func NewActuator(networkManager kubevirt.NetworkManager, logger logr.Logger) infrastructure.Actuator {
 
 	return &actuator{
-		logger: log.Log.WithName("infrastructure-actuator"),
+		networkManager: networkManager,
+		logger:         logger.WithName("kubevirt-infrastructure-actuator"),
 	}
 }

--- a/pkg/controller/infrastructure/add.go
+++ b/pkg/controller/infrastructure/add.go
@@ -19,12 +19,15 @@ import (
 
 	"github.com/gardener/gardener/extensions/pkg/controller/infrastructure"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
 var (
 	// DefaultAddOptions are the default AddOptions for AddToManager.
 	DefaultAddOptions = AddOptions{}
+
+	logger = log.Log.WithName("kubevirt-infrastructure-controller")
 )
 
 // AddOptions are options to apply when adding the KubeVirt infrastructure controller to the manager.
@@ -39,7 +42,7 @@ type AddOptions struct {
 // The opts.Reconciler is being set with a newly instantiated actuator.
 func AddToManagerWithOptions(mgr manager.Manager, opts AddOptions) error {
 	return infrastructure.Add(mgr, infrastructure.AddArgs{
-		Actuator:          NewActuator(),
+		Actuator:          NewActuator(kubevirt.NewNetworkManager(kubevirt.ClientFactoryFunc(kubevirt.GetClient), logger), logger),
 		ControllerOptions: opts.Controller,
 		Predicates:        infrastructure.DefaultPredicates(opts.IgnoreOperationAnnotation),
 		Type:              kubevirt.Type,

--- a/pkg/controller/worker/actuator_delete.go
+++ b/pkg/controller/worker/actuator_delete.go
@@ -46,15 +46,14 @@ func (a *actuator) Delete(ctx context.Context, worker *extensionsv1alpha1.Worker
 	return a.deleteDataVolumes(ctx, kubeconfig, worker, machineClasses)
 }
 
-func (a *actuator) deleteDataVolumes(ctx context.Context, kubeconfig []byte, worker *extensionsv1alpha1.Worker,
-	machineClasses *machinev1alpha1.MachineClassList) error {
-	dataVolumeLabels := map[string]string{
+func (a *actuator) deleteDataVolumes(ctx context.Context, kubeconfig []byte, worker *extensionsv1alpha1.Worker, machineClasses *machinev1alpha1.MachineClassList) error {
+	labels := map[string]string{
 		clusterLabel: worker.Namespace,
 	}
 
-	dataVolumes, err := a.dataVolumeManager.ListDataVolumes(ctx, kubeconfig, client.MatchingLabels(dataVolumeLabels))
+	dataVolumes, err := a.dataVolumeManager.ListDataVolumes(ctx, kubeconfig, labels)
 	if err != nil {
-		return errors.Wrapf(err, "could not list data volumes in namespace %q", worker.Namespace)
+		return errors.Wrap(err, "could not list data volumes")
 	}
 
 	for _, dataVolume := range dataVolumes.Items {

--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -301,8 +301,8 @@ func (w *workerDelegate) createOrUpdateMachineClassVolumes(ctx context.Context) 
 	}
 
 	for name, dataVolumeSpec := range w.machineClassVolumes {
-		if err := w.dataVolumeManager.CreateOrUpdateDataVolume(ctx, kubeconfig, name, labels, *dataVolumeSpec); err != nil {
-			return errors.Wrapf(err, "could not create data volume for machine class %q", name)
+		if _, err := w.dataVolumeManager.CreateOrUpdateDataVolume(ctx, kubeconfig, name, labels, *dataVolumeSpec); err != nil {
+			return errors.Wrapf(err, "could not create or update data volume %q", name)
 		}
 	}
 

--- a/pkg/kubevirt/client_factory.go
+++ b/pkg/kubevirt/client_factory.go
@@ -1,0 +1,71 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubevirt
+
+import (
+	"sync"
+
+	"github.com/pkg/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// ClientFactory creates a client from the kubeconfig saved in the "kubeconfig" field of the given secret.
+type ClientFactory interface {
+	// GetClient creates a client from the kubeconfig saved in the "kubeconfig" field of the given secret.
+	// It also returns the namespace of the kubeconfig's current context.
+	GetClient(kubeconfig []byte) (client.Client, string, error)
+}
+
+// ClientFactoryFunc is a function that implements ClientFactory.
+type ClientFactoryFunc func(kubeconfig []byte) (client.Client, string, error)
+
+// GetClient creates a client from the kubeconfig saved in the "kubeconfig" field of the given secret.
+// It also returns the namespace of the kubeconfig's current context.
+func (f ClientFactoryFunc) GetClient(kubeconfig []byte) (client.Client, string, error) {
+	return f(kubeconfig)
+}
+
+type getClientResult struct {
+	client    client.Client
+	namespace string
+}
+
+// getClient retrieves and returns a client and a namespace from the given clients cache.
+// If not found, it creates a client and gets a namespace using the given client factory, adds them to the cache, and returns them.
+func getClient(kubeconfig []byte, clientFactory ClientFactory, clients map[string]*getClientResult, mx *sync.RWMutex) (client.Client, string, error) {
+	// Check clients cache
+	key := string(kubeconfig)
+	mx.RLock()
+	if gcr, ok := clients[key]; ok {
+		mx.RUnlock()
+		return gcr.client, gcr.namespace, nil
+	}
+	mx.RUnlock()
+
+	// Create a new client for the given kubeconfig
+	c, namespace, err := clientFactory.GetClient(kubeconfig)
+	if err != nil {
+		return nil, "", errors.Wrap(err, "could not create client from kubeconfig")
+	}
+
+	// Add client to cache and return it
+	mx.Lock()
+	clients[key] = &getClientResult{
+		client:    c,
+		namespace: namespace,
+	}
+	mx.Unlock()
+	return c, namespace, nil
+}

--- a/pkg/kubevirt/network.go
+++ b/pkg/kubevirt/network.go
@@ -1,0 +1,170 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubevirt
+
+import (
+	"context"
+	"sync"
+
+	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+	"github.com/go-logr/logr"
+	networkv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+	"github.com/pkg/errors"
+	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/retry"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+const (
+	// nadCRDName is the NetworkAttachmentDefinition CRD name
+	nadCRDName = "network-attachment-definitions.k8s.cni.cncf.io"
+)
+
+// NetworkManager manages Multus NetworkAttachmentDefinitions.
+type NetworkManager interface {
+	// CreateOrUpdateNetworkAttachmentDefinition creates or updates a NetworkAttachmentDefinition with the given name, labels, and config.
+	CreateOrUpdateNetworkAttachmentDefinition(ctx context.Context, kubeconfig []byte, name string, labels map[string]string, config string) (*networkv1.NetworkAttachmentDefinition, error)
+	// DeleteNetworkAttachmentDefinition deletes the NetworkAttachmentDefinition with the given name.
+	DeleteNetworkAttachmentDefinition(ctx context.Context, kubeconfig []byte, name string) error
+	// GetNetworkAttachmentDefinition retrieves the NetworkAttachmentDefinition with the given name and namespace.
+	GetNetworkAttachmentDefinition(ctx context.Context, kubeconfig []byte, name, namespace string) (*networkv1.NetworkAttachmentDefinition, error)
+	// ListNetworkAttachmentDefinitions lists all NetworkAttachmentDefinitions with the given labels.
+	ListNetworkAttachmentDefinitions(ctx context.Context, kubeconfig []byte, labels map[string]string) (*networkv1.NetworkAttachmentDefinitionList, error)
+}
+
+type networkManager struct {
+	clientFactory ClientFactory
+	logger        logr.Logger
+	clients       map[string]*getClientResult
+	mx            sync.RWMutex
+}
+
+// NewNetworkManager creates a new NetworkManager with the given client factory and logger.
+func NewNetworkManager(clientFactory ClientFactory, logger logr.Logger) NetworkManager {
+	return &networkManager{
+		clientFactory: clientFactory,
+		logger:        logger.WithName("kubevirt-network-manager"),
+		clients:       make(map[string]*getClientResult),
+	}
+}
+
+// CreateOrUpdateNetworkAttachmentDefinition creates or updates a NetworkAttachmentDefinition with the given name, labels, and config.
+func (n *networkManager) CreateOrUpdateNetworkAttachmentDefinition(ctx context.Context, kubeconfig []byte, name string, labels map[string]string, config string) (*networkv1.NetworkAttachmentDefinition, error) {
+	c, namespace, err := n.getClient(kubeconfig)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create or update the NetworkAttachmentDefinition in the provider cluster
+	n.logger.Info("Creating or updating NetworkAttachmentDefinition", "name", name, "namespace", namespace)
+	nad := &networkv1.NetworkAttachmentDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+	if err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		_, err := controllerutil.CreateOrUpdate(ctx, c, nad, func() error {
+			nad.Labels = labels
+			nad.Spec.Config = config
+			return nil
+		})
+		return err
+	}); err != nil {
+		return nil, errors.Wrapf(err, "could not create or update NetworkAttachmentDefinition %q", kutil.ObjectName(nad))
+	}
+
+	return nad, nil
+}
+
+// DeleteNetworkAttachmentDefinition deletes the NetworkAttachmentDefinition with the given name.
+func (n *networkManager) DeleteNetworkAttachmentDefinition(ctx context.Context, kubeconfig []byte, name string) error {
+	c, namespace, err := n.getClient(kubeconfig)
+	if err != nil {
+		return err
+	}
+
+	// Delete the NetworkAttachmentDefinition in the provider cluster
+	n.logger.Info("Deleting NetworkAttachmentDefinition", "name", name, "namespace", namespace)
+	nad := &networkv1.NetworkAttachmentDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+	if err := client.IgnoreNotFound(c.Delete(ctx, nad)); err != nil {
+		return errors.Wrapf(err, "could not delete NetworkAttachmentDefinition %q", kutil.ObjectName(nad))
+	}
+
+	return nil
+}
+
+// GetNetworkAttachmentDefinition retrieves the NetworkAttachmentDefinition with the given name and namespace.
+func (n *networkManager) GetNetworkAttachmentDefinition(ctx context.Context, kubeconfig []byte, name, namespace string) (*networkv1.NetworkAttachmentDefinition, error) {
+	c, kubeconfigNamespace, err := n.getClient(kubeconfig)
+	if err != nil {
+		return nil, err
+	}
+
+	// Determine NetworkAttachmentDefinition namespace
+	if namespace == "" {
+		namespace = kubeconfigNamespace
+	}
+
+	// Get the NetworkAttachmentDefinition from the provider cluster
+	n.logger.Info("Getting NetworkAttachmentDefinition", "name", name, "namespace", namespace)
+	nadKey := kutil.Key(namespace, name)
+	nad := &networkv1.NetworkAttachmentDefinition{}
+	if err := c.Get(ctx, nadKey, nad); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, errors.Wrapf(err, "NetworkAttachmentDefinition '%v' not found", nadKey)
+		}
+		return nil, errors.Wrapf(err, "could not get NetworkAttachmentDefinition '%v'", nadKey)
+	}
+
+	return nad, nil
+}
+
+// ListNetworkAttachmentDefinitions lists all NetworkAttachmentDefinitions with the given labels.
+func (n *networkManager) ListNetworkAttachmentDefinitions(ctx context.Context, kubeconfig []byte, labels map[string]string) (*networkv1.NetworkAttachmentDefinitionList, error) {
+	c, namespace, err := n.getClient(kubeconfig)
+	if err != nil {
+		return nil, err
+	}
+
+	// Check if the NetworkAttachmentDefinition CRD exists
+	nadList := &networkv1.NetworkAttachmentDefinitionList{}
+	if err := c.Get(ctx, kutil.Key("", nadCRDName), &apiextensionsv1beta1.CustomResourceDefinition{}); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nadList, nil
+		}
+		return nil, errors.Wrapf(err, "could not get CRD %q", nadCRDName)
+	}
+
+	// List all NetworkAttachmentDefinitions in the provider cluster matching the given namespace and labels
+	n.logger.Info("Listing NetworkAttachmentDefinitions", "namespace", namespace, "labels", labels)
+	if err := c.List(ctx, nadList, client.InNamespace(namespace), client.MatchingLabels(labels)); err != nil {
+		return nil, errors.Wrap(err, "could not list NetworkAttachmentDefinitions")
+	}
+
+	return nadList, nil
+}
+
+func (n *networkManager) getClient(kubeconfig []byte) (client.Client, string, error) {
+	return getClient(kubeconfig, n.clientFactory, n.clients, &n.mx)
+}

--- a/pkg/mock/kubevirt/mocks.go
+++ b/pkg/mock/kubevirt/mocks.go
@@ -76,11 +76,12 @@ func (m *MockDataVolumeManager) EXPECT() *MockDataVolumeManagerMockRecorder {
 }
 
 // CreateOrUpdateDataVolume mocks base method.
-func (m *MockDataVolumeManager) CreateOrUpdateDataVolume(arg0 context.Context, arg1 []byte, arg2 string, arg3 map[string]string, arg4 v1alpha1.DataVolumeSpec) error {
+func (m *MockDataVolumeManager) CreateOrUpdateDataVolume(arg0 context.Context, arg1 []byte, arg2 string, arg3 map[string]string, arg4 v1alpha1.DataVolumeSpec) (*v1alpha1.DataVolume, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateOrUpdateDataVolume", arg0, arg1, arg2, arg3, arg4)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(*v1alpha1.DataVolume)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // CreateOrUpdateDataVolume indicates an expected call of CreateOrUpdateDataVolume.
@@ -103,37 +104,17 @@ func (mr *MockDataVolumeManagerMockRecorder) DeleteDataVolume(arg0, arg1, arg2 i
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteDataVolume", reflect.TypeOf((*MockDataVolumeManager)(nil).DeleteDataVolume), arg0, arg1, arg2)
 }
 
-// GetDataVolume mocks base method.
-func (m *MockDataVolumeManager) GetDataVolume(arg0 context.Context, arg1 []byte, arg2 string) (*v1alpha1.DataVolume, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetDataVolume", arg0, arg1, arg2)
-	ret0, _ := ret[0].(*v1alpha1.DataVolume)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetDataVolume indicates an expected call of GetDataVolume.
-func (mr *MockDataVolumeManagerMockRecorder) GetDataVolume(arg0, arg1, arg2 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDataVolume", reflect.TypeOf((*MockDataVolumeManager)(nil).GetDataVolume), arg0, arg1, arg2)
-}
-
 // ListDataVolumes mocks base method.
-func (m *MockDataVolumeManager) ListDataVolumes(arg0 context.Context, arg1 []byte, arg2 ...client.ListOption) (*v1alpha1.DataVolumeList, error) {
+func (m *MockDataVolumeManager) ListDataVolumes(arg0 context.Context, arg1 []byte, arg2 map[string]string) (*v1alpha1.DataVolumeList, error) {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{arg0, arg1}
-	for _, a := range arg2 {
-		varargs = append(varargs, a)
-	}
-	ret := m.ctrl.Call(m, "ListDataVolumes", varargs...)
+	ret := m.ctrl.Call(m, "ListDataVolumes", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*v1alpha1.DataVolumeList)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListDataVolumes indicates an expected call of ListDataVolumes.
-func (mr *MockDataVolumeManagerMockRecorder) ListDataVolumes(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+func (mr *MockDataVolumeManagerMockRecorder) ListDataVolumes(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{arg0, arg1}, arg2...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListDataVolumes", reflect.TypeOf((*MockDataVolumeManager)(nil).ListDataVolumes), varargs...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListDataVolumes", reflect.TypeOf((*MockDataVolumeManager)(nil).ListDataVolumes), arg0, arg1, arg2)
 }


### PR DESCRIPTION
**How to categorize this PR?**

/area quality
/kind technical-debh
/priority normal
/platform kubevirt

**What this PR does / why we need it**:
Refactors the infra controller to follow the model of the worker controller:
* Extract NAD management logic into `kubevirt.NetworkManager`
* Refactor `kubevirt.DataVolumeManager` for consistency with `kubevirt.NetworkManager`: remove unused methods, add logging and retry on conflict, update method signatures, etc.
* Introduce client caching for both managers
* Ensure that loggers are always injected and used consistently in all controllers

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Based on #83 , which should be merged first before merging this one.

**Release note**:

```improvement operator
NONE
```
