### PR TITLE
Update machine-controller-manager-provider-kubevirt image to v0.2.0

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -6,7 +6,7 @@ images:
 - name: machine-controller-manager-provider-kubevirt
   sourceRepository: github.com/gardener/machine-controller-manager-provider-kubevirt
   repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager-provider-kubevirt
-  tag: "v0.1.0"
+  tag: "v0.2.0"
 - name: cloud-controller-manager
   sourceRepository: github.com/kubevirt/cloud-provider-kubevirt
   repository: eu.gcr.io/gardener-project/kubevirt-cloud-controller-manager


### PR DESCRIPTION
**How to categorize this PR?**

/area quality
/kind enhancement
/priority normal
/platform kubevirt

**What this PR does / why we need it**:
Updates the `machine-controller-manager-provider-kubevirt` image to v0.2.0.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```improvement operator
NONE
```
